### PR TITLE
Updates types in package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "dist/index.node.cjs",
   "browser": "dist/index.browser.js",
   "module": "dist/index.node.mjs",
-  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "browser": "./dist/index.browser.js",
       "require": "./dist/index.node.cjs",
-      "default": "./dist/index.node.mjs"
+      "default": "./dist/index.node.mjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
# PR: Updates exported types in package.

## Suggested Change
Modification of package.json to change how types are exported as the [`types` property is not used when `exports` are declared](https://stackoverflow.com/a/76212193).

Currently an error is coming from the lack of exported types making this very difficult to use when installed from NPM.

![image](https://github.com/jchv/js-srp/assets/22136781/9f993b74-95af-42f2-853d-fd106815832b)


## Testing strategy.

I applied these changes to the `package.json` and pushed them into my `node_modules` for the project I'm working on, it then found the type definitions!